### PR TITLE
Stringify large object graphs more concisely.

### DIFF
--- a/gjstest/public/matchers/equality_matchers_test.js
+++ b/gjstest/public/matchers/equality_matchers_test.js
@@ -163,9 +163,9 @@ EqualsTest.prototype.Description = function() {
   expectEq('is not a reference to: function fooBar(baz)',
            matcher.getNegativeDescription());
 
-  function MyClass() {}
-  MyClass.prototype.gjstestEquals = function() { return true; };
-  matcher = equals(new MyClass);
+  matcher = equals({
+    gjstestEquals: function() { return true; }
+  });
   expectEq('{ gjstestEquals: function () }', matcher.getDescription());
   expectEq('does not equal: { gjstestEquals: function () }',
            matcher.getNegativeDescription());

--- a/gjstest/public/stringify.js
+++ b/gjstest/public/stringify.js
@@ -17,6 +17,11 @@
  * Given an abitrary object, return a human-readble, 1-line description of that
  * object for use in messages about expectations.
  *
+ * Various abbreviations are applied to try to keep the output reasonably
+ * compact. Long arrays and deeply nested objects are truncated. Repeated
+ * references to the same object are only expanded in the first case. Methods on
+ * user-defined classes are not printed.
+ *
  * This function makes use of toString methods on the objects it sees, if any.
  * The display of user-defined types may therefore be customised by defining
  * such methods.
@@ -29,62 +34,45 @@
  * @return {!string}
  */
 gjstest.stringify = function(obj) {
+  return gjstest.internal.stringifyToDepth(obj, 5);
+}
+
+
+/**
+ * @param {*} obj
+ * @param {number} depth Depth to which objects should be expanded.
+ * @return {!string}
+ */
+gjstest.internal.stringifyToDepth = function(obj, depth) {
   var naiveResult = '' + obj;
 
   // Special-case: arrays and arguments should have their values printed:
   //     [ 1, 2, 'foo' ]
   if (obj instanceof Array || naiveResult == '[object Arguments]') {
-    if (obj.length == 0) return '[]';
-
-    // Was this array already seen in an invocation of this function further
-    // down the stack?
-    if (obj.__gjstest_stringify_already_seen) return '(cyclic reference)';
-
-    // Annotate this object temporarily; clean up later.
-    obj.__gjstest_stringify_already_seen = true;
-
-    var descriptions = [];
+    var description = new gjstest.internal.ObjectDescriptionBuilder(obj, depth);
     for (var i = 0; i < obj.length; ++i) {
-      // Leave a blank space for indexes where there's a missing element.
       if (!obj.hasOwnProperty(i)) {
-        descriptions.push('');
-        continue;
+        // Leave a blank space for indexes where there's a missing element.
+        description.addRawText('');
+      } else {
+        description.addArrayElement(i);
       }
-
-      descriptions.push(gjstest.stringify(obj[i]));
     }
-
-    // Clear the tracking property.
-    delete obj.__gjstest_stringify_already_seen;
-
-    return '[ ' + descriptions.join(', ') + ' ]';
+    return description.finish('[', ']');
   }
 
   // Special-case: objects should have their keys and values printed:
   //     { foo: 1, bar: { baz: 'asd' } }
   if (naiveResult == '[object Object]') {
-    // Was this array already seen in an invocation of this function further
-    // down the stack?
-    if (obj.__gjstest_stringify_already_seen) return '(cyclic reference)';
-
-    // Annotate this object temporarily; clean up later.
-    obj.__gjstest_stringify_already_seen = true;
-
-    var keyValueDescriptions = [];
+    var description = new gjstest.internal.ObjectDescriptionBuilder(obj, depth);
     for (var key in obj) {
-      // Skip this key if it's our special tracker property.
-      if (key == '__gjstest_stringify_already_seen') continue;
-
-      var value = obj[key];
-      keyValueDescriptions.push(key + ': ' + gjstest.stringify(value));
+      if (!obj.hasOwnProperty(key)) {
+        // Ignore inherited properties.
+      } else {
+        description.addKey(key);
+      }
     }
-
-    // Clear the tracking property.
-    delete obj.__gjstest_stringify_already_seen;
-
-    if (keyValueDescriptions.length == 0) return '{}';
-
-    return '{ ' + keyValueDescriptions.join(', ') + ' }';
+    return description.finish('{', '}');
   }
 
   // Special-case: strings should be surrounded in quotation marks, and have
@@ -107,4 +95,144 @@ gjstest.stringify = function(obj) {
   }
 
   return '' + obj;
+};
+
+
+/**
+ * Utility object for constructing a text representation of an object. The
+ * output is intended for debugging purposes rather than serialization.
+ *
+ * Between the contruction of this object and the invocation of its finish()
+ * method, a special property '__gjstest_next_object' will exist on any objects
+ * whose properties are being added to the description. Its presence indicates
+ * that the object has been visited at least once, so that we can skip it on
+ * subsequent visits. It also forms a linked list of visited objects, so that
+ * finish() can find all modified objects and remove the property.
+ *
+ * @param {*} parent
+ * @param {number} depth Depth to which objects should be expanded.
+ * @constructor
+ * @struct
+ */
+gjstest.internal.ObjectDescriptionBuilder = function(parent, depth) {
+  this.depth_ = depth;
+  this.obj_ = parent;
+  this.parts_ = [];
+  this.isRoot_ = !parent.__gjstest_next_object;
+  if (this.isRoot_) {
+    parent.__gjstest_next_object = {};
+  }
+};
+
+
+/**
+ * Add the element at a given index to the object's description. The object is
+ * assumed to be an array.
+ *
+ * @param {number} index
+ */
+gjstest.internal.ObjectDescriptionBuilder.prototype.addArrayElement =
+    function(index) {
+  this.addKeyWithPrefix('' + index, '');
+}
+
+
+/**
+ * Add one of the object's properties to the description, with the key name
+ * included.
+ *
+ * @param {string} key
+ */
+gjstest.internal.ObjectDescriptionBuilder.prototype.addKey = function(key) {
+  this.addKeyWithPrefix(key, key + ': ');
+}
+
+
+/**
+ * Add one of the parent object's properties as part of the description.
+ *
+ * @param {string} prefix
+ * @param {string} key
+ */
+gjstest.internal.ObjectDescriptionBuilder.prototype.addKeyWithPrefix =
+    function(key, prefix) {
+  if (key === '__gjstest_next_object') {
+    return;
+  }
+
+  // Beyond the depth limit, indicate whether the object is empty but otherwise
+  // do not expand its contents.
+  if (this.depth_ <= 0) {
+    this.parts_[0] = '...';
+    return;
+  }
+
+  // Truncate long arrays and leave an indicator that elements were removed.
+  if (this.parts_.length == 25) {
+    this.parts_.push('...');
+  }
+  if (this.parts_.length > 25) {
+    return;
+  }
+
+  var child = this.obj_[key];
+
+  // Skip the child if it has already been expanded. Using depth=0 causes
+  // arrays to appear as '[]' or '[...]' (depending on whether they are empty)
+  // but not to be expanded further.
+  if (child && child.__gjstest_next_object) {
+    this.parts_.push(prefix + gjstest.internal.stringifyToDepth(child, 0));
+    return;
+  }
+
+  // If the child can have properties, insert it into the list of seen objects.
+  if (child) {
+    child.__gjstest_next_object = this.obj_.__gjstest_next_object;
+    if (child.__gjstest_next_object) {
+      this.obj_.__gjstest_next_object = child;
+    }
+  }
+
+  this.parts_.push(
+      prefix + gjstest.internal.stringifyToDepth(child, this.depth_ - 1));
+};
+
+
+/**
+ * Add raw text to the description. It will be separated from other parts of the
+ * description by a comma, as if it were a child element.
+ *
+ * @param {string} text
+ */
+gjstest.internal.ObjectDescriptionBuilder.prototype.addRawText =
+    function(text) {
+  this.parts_.push(text);
+};
+
+
+/**
+ * Clean up temporary data structures and return the assembled description.
+ *
+ * @param {string} prefix
+ * @param {string} suffix
+ */
+gjstest.internal.ObjectDescriptionBuilder.prototype.finish =
+    function(prefix, suffix) {
+  // Clean up the list of visited objects.
+  if (this.isRoot_) {
+    var obj = this.obj_;
+    while (obj) {
+      var nextObj = obj.__gjstest_next_object;
+      delete obj.__gjstest_next_object;
+      obj = nextObj;
+    }
+  }
+
+  if (this.parts_.length == 0) {
+    return prefix + suffix;
+  } else if (this.depth_ <= 0) {
+    return prefix + '...' + suffix;
+  } else {
+    return prefix + ' ' + this.parts_.join(', ') + ' ' + suffix;
+  }
 };


### PR DESCRIPTION
We sometimes see very large output in the test log (thousands of lines)
when an expectation fails and it tries to stringify a large graph of
objects.  This change applies several techniques to try to keep the
output volume of gjstest.stringify manageable.

- Objects/arrays beyond a certain nesting depth are not expanded.

- Inherited methods are not shown. Instances of user-defined classes
  often have dozens of methods that clutter the output.

- Only the first reference to each object is expanded, whereas
  previously only recursively cyclical references were handled. It does
  this by building a linked list of objects that it has visited.