### PR TITLE
Show the full user stack trace on failure.

### DIFF
--- a/gjstest/internal/integration_tests/exception.golden.txt
+++ b/gjstest/internal/integration_tests/exception.golden.txt
@@ -18,8 +18,8 @@ Stack:
 
 [  FAILED  ] ExceptionTest.NotAFunctionError (1 ms)
 [ RUN      ] ExceptionTest.ErrorInMatcherFactory
-exception_test.js:32
 TypeError: isNearNumber requires two number arguments
+        at exception_test.js:32
 
 [  FAILED  ] ExceptionTest.ErrorInMatcherFactory (1 ms)
 [ RUN      ] ExceptionTest.StackOverflow

--- a/gjstest/internal/integration_tests/exception.golden.xml
+++ b/gjstest/internal/integration_tests/exception.golden.xml
@@ -17,8 +17,8 @@ Stack:
     run_test.js:37]]></failure>
  </testcase>
  <testcase name="ExceptionTest.ErrorInMatcherFactory" time="0.01">
-  <failure><![CDATA[exception_test.js:32
-TypeError: isNearNumber requires two number arguments]]></failure>
+  <failure><![CDATA[TypeError: isNearNumber requires two number arguments
+        at exception_test.js:32]]></failure>
  </testcase>
  <testcase name="ExceptionTest.StackOverflow" time="0.01">
   <failure><![CDATA[RangeError: Maximum call stack size exceeded

--- a/gjstest/internal/integration_tests/failing.golden.txt
+++ b/gjstest/internal/integration_tests/failing.golden.txt
@@ -2,135 +2,143 @@
 [ RUN      ] FailingTest.PassingTest1
 [       OK ] FailingTest.PassingTest1 (1 ms)
 [ RUN      ] FailingTest.FailingTest1
-failing_test.js:27
 Expected: evaluates to false
 Actual:   'a'
+        at failing_test.js:27
 
 [  FAILED  ] FailingTest.FailingTest1 (1 ms)
 [ RUN      ] FailingTest.FailingTest2
-failing_test.js:31
 Expected: evaluates to false
 Actual:   2
+        at failing_test.js:31
 
-failing_test.js:32
 Expected: is an array or Arguments object of length 3 with elements matching: [ 1, 2, 3 ]
 Actual:   [ 1, 2 ], which has length 2
+        at failing_test.js:32
 
 [  FAILED  ] FailingTest.FailingTest2 (1 ms)
 [ RUN      ] FailingTest.StringMatchers
-failing_test.js:36
 Expected: partially matches regex: /enchilada/
 Actual:   'burritos and tacos'
+        at failing_test.js:36
 
-failing_test.js:37
 Expected: is a string containing the substring 'enchilada'
 Actual:   'burritos and tacos'
+        at failing_test.js:37
 
-failing_test.js:38
 Expected: is not a string containing the substring 'taco'
 Actual:   'tacos'
+        at failing_test.js:38
 
 [  FAILED  ] FailingTest.StringMatchers (1 ms)
 [ RUN      ] FailingTest.FailureWithLogOutput
-failing_test.js:42
 Expected: evaluates to false
 Actual:   2
+        at failing_test.js:42
 
 foo bar
-failing_test.js:44
 Expected: evaluates to false
 Actual:   3
+        at failing_test.js:44
 
 [  FAILED  ] FailingTest.FailureWithLogOutput (1 ms)
 [ RUN      ] FailingTest.MissingArrayElementWithRecursivelyEquals
-failing_test.js:54
 Expected: recursively equals [ 0, undefined, 2 ]
 Actual:   [ 0, , 2 ], which differs in key 1
+        at failing_test.js:54
 
 [  FAILED  ] FailingTest.MissingArrayElementWithRecursivelyEquals (1 ms)
 [ RUN      ] FailingTest.PassingTest2
 [       OK ] FailingTest.PassingTest2 (1 ms)
 [ RUN      ] FailingTest.NumberExpectations
-failing_test.js:62
 Expected: is less than 0
 Actual:   1
+        at failing_test.js:62
 
-failing_test.js:63
 Expected: is less than 1
 Actual:   1
+        at failing_test.js:63
 
-failing_test.js:65
 Expected: is less than or equal to -1
 Actual:   1
+        at failing_test.js:65
 
-failing_test.js:66
 Expected: is less than or equal to 0
 Actual:   1
+        at failing_test.js:66
 
-failing_test.js:68
 Expected: is greater than 7
 Actual:   7
+        at failing_test.js:68
 
-failing_test.js:69
 Expected: is greater than 9
 Actual:   7
+        at failing_test.js:69
 
-failing_test.js:71
 Expected: is greater than or equal to 8
 Actual:   7
+        at failing_test.js:71
 
-failing_test.js:72
 Expected: is greater than or equal to 9
 Actual:   7
+        at failing_test.js:72
 
 [  FAILED  ] FailingTest.NumberExpectations (1 ms)
 [ RUN      ] FailingTest.UserErrors
-failing_test.js:76
 Expected: is a string containing the substring 'burrito'
 Actual:   'taco'
 foo
+        at failing_test.js:76
 
-failing_test.js:77
 Expected: ''
 Actual:   'a'
 foo
+        at failing_test.js:77
 
-failing_test.js:78
 Expected: does not equal: 'a'
 Actual:   'a'
 foo
+        at failing_test.js:78
 
-failing_test.js:79
 Expected: false
 Actual:   true
 foo
+        at failing_test.js:79
 
-failing_test.js:80
 Expected: true
 Actual:   false
 foo
+        at failing_test.js:80
 
-failing_test.js:81
 Expected: is greater than or equal to 1
 Actual:   0
 foo
+        at failing_test.js:81
 
-failing_test.js:82
 Expected: is greater than 0
 Actual:   0
 foo
+        at failing_test.js:82
 
-failing_test.js:83
 Expected: is less than or equal to 2
 Actual:   3
 foo
+        at failing_test.js:83
 
-failing_test.js:84
 Expected: is less than 2
 Actual:   2
 foo
+        at failing_test.js:84
 
 [  FAILED  ] FailingTest.UserErrors (1 ms)
+[ RUN      ] FailingTest.FailingTestWithStack
+Expected: evaluates to false
+Actual:   'a'
+        at failing_test.js:96
+        at failing_test.js:92
+        at failing_test.js:88
+
+[  FAILED  ] FailingTest.FailingTestWithStack (1 ms)
 [----------]
 
 [  FAILED  ]

--- a/gjstest/internal/integration_tests/failing.golden.xml
+++ b/gjstest/internal/integration_tests/failing.golden.xml
@@ -1,125 +1,132 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="Google JS tests" failures="7" time="0.01">
+<testsuite name="Google JS tests" failures="8" time="0.01">
  <testcase name="FailingTest.PassingTest1" time="0.01"/>
  <testcase name="FailingTest.FailingTest1" time="0.01">
-  <failure><![CDATA[failing_test.js:27
-Expected: evaluates to false
-Actual:   'a']]></failure>
+  <failure><![CDATA[Expected: evaluates to false
+Actual:   'a'
+        at failing_test.js:27]]></failure>
  </testcase>
  <testcase name="FailingTest.FailingTest2" time="0.01">
-  <failure><![CDATA[failing_test.js:31
-Expected: evaluates to false
+  <failure><![CDATA[Expected: evaluates to false
 Actual:   2
+        at failing_test.js:31
 
-failing_test.js:32
 Expected: is an array or Arguments object of length 3 with elements matching: [ 1, 2, 3 ]
-Actual:   [ 1, 2 ], which has length 2]]></failure>
+Actual:   [ 1, 2 ], which has length 2
+        at failing_test.js:32]]></failure>
  </testcase>
  <testcase name="FailingTest.StringMatchers" time="0.01">
-  <failure><![CDATA[failing_test.js:36
-Expected: partially matches regex: /enchilada/
+  <failure><![CDATA[Expected: partially matches regex: /enchilada/
 Actual:   'burritos and tacos'
+        at failing_test.js:36
 
-failing_test.js:37
 Expected: is a string containing the substring 'enchilada'
 Actual:   'burritos and tacos'
+        at failing_test.js:37
 
-failing_test.js:38
 Expected: is not a string containing the substring 'taco'
-Actual:   'tacos']]></failure>
+Actual:   'tacos'
+        at failing_test.js:38]]></failure>
  </testcase>
  <testcase name="FailingTest.FailureWithLogOutput" time="0.01">
-  <failure><![CDATA[failing_test.js:42
-Expected: evaluates to false
+  <failure><![CDATA[Expected: evaluates to false
 Actual:   2
+        at failing_test.js:42
 
-failing_test.js:44
 Expected: evaluates to false
-Actual:   3]]></failure>
+Actual:   3
+        at failing_test.js:44]]></failure>
  </testcase>
  <testcase name="FailingTest.MissingArrayElementWithRecursivelyEquals" time="0.01">
-  <failure><![CDATA[failing_test.js:54
-Expected: recursively equals [ 0, undefined, 2 ]
-Actual:   [ 0, , 2 ], which differs in key 1]]></failure>
+  <failure><![CDATA[Expected: recursively equals [ 0, undefined, 2 ]
+Actual:   [ 0, , 2 ], which differs in key 1
+        at failing_test.js:54]]></failure>
  </testcase>
  <testcase name="FailingTest.PassingTest2" time="0.01"/>
  <testcase name="FailingTest.NumberExpectations" time="0.01">
-  <failure><![CDATA[failing_test.js:62
-Expected: is less than 0
+  <failure><![CDATA[Expected: is less than 0
 Actual:   1
+        at failing_test.js:62
 
-failing_test.js:63
 Expected: is less than 1
 Actual:   1
+        at failing_test.js:63
 
-failing_test.js:65
 Expected: is less than or equal to -1
 Actual:   1
+        at failing_test.js:65
 
-failing_test.js:66
 Expected: is less than or equal to 0
 Actual:   1
+        at failing_test.js:66
 
-failing_test.js:68
 Expected: is greater than 7
 Actual:   7
+        at failing_test.js:68
 
-failing_test.js:69
 Expected: is greater than 9
 Actual:   7
+        at failing_test.js:69
 
-failing_test.js:71
 Expected: is greater than or equal to 8
 Actual:   7
+        at failing_test.js:71
 
-failing_test.js:72
 Expected: is greater than or equal to 9
-Actual:   7]]></failure>
+Actual:   7
+        at failing_test.js:72]]></failure>
  </testcase>
  <testcase name="FailingTest.UserErrors" time="0.01">
-  <failure><![CDATA[failing_test.js:76
-Expected: is a string containing the substring 'burrito'
+  <failure><![CDATA[Expected: is a string containing the substring 'burrito'
 Actual:   'taco'
 foo
+        at failing_test.js:76
 
-failing_test.js:77
 Expected: ''
 Actual:   'a'
 foo
+        at failing_test.js:77
 
-failing_test.js:78
 Expected: does not equal: 'a'
 Actual:   'a'
 foo
+        at failing_test.js:78
 
-failing_test.js:79
 Expected: false
 Actual:   true
 foo
+        at failing_test.js:79
 
-failing_test.js:80
 Expected: true
 Actual:   false
 foo
+        at failing_test.js:80
 
-failing_test.js:81
 Expected: is greater than or equal to 1
 Actual:   0
 foo
+        at failing_test.js:81
 
-failing_test.js:82
 Expected: is greater than 0
 Actual:   0
 foo
+        at failing_test.js:82
 
-failing_test.js:83
 Expected: is less than or equal to 2
 Actual:   3
 foo
+        at failing_test.js:83
 
-failing_test.js:84
 Expected: is less than 2
 Actual:   2
-foo]]></failure>
+foo
+        at failing_test.js:84]]></failure>
+ </testcase>
+ <testcase name="FailingTest.FailingTestWithStack" time="0.01">
+  <failure><![CDATA[Expected: evaluates to false
+Actual:   'a'
+        at failing_test.js:96
+        at failing_test.js:92
+        at failing_test.js:88]]></failure>
  </testcase>
 </testsuite>

--- a/gjstest/internal/integration_tests/failing_test.js
+++ b/gjstest/internal/integration_tests/failing_test.js
@@ -83,3 +83,15 @@ FailingTest.prototype.UserErrors = function() {
   expectLe(3, 2, 'foo');
   expectLt(2, 2, 'foo');
 };
+
+FailingTest.prototype.FailingTestWithStack = function() {
+  helper1();
+};
+
+function helper1() {
+  helper2();
+}
+
+function helper2() {
+  expectThat('a', evalsToFalse);
+}

--- a/gjstest/internal/integration_tests/mocks.golden.txt
+++ b/gjstest/internal/integration_tests/mocks.golden.txt
@@ -118,8 +118,8 @@ Expected 1 call; called 0 times.
 
 [  FAILED  ] MocksTest.PrecedingExpectThat (1 ms)
 [ RUN      ] MocksTest.ExpectCallWithNonMockFunction
-mocks_test.js:176
 TypeError: Supplied function is not a mock.
+        at mocks_test.js:176
 
 [  FAILED  ] MocksTest.ExpectCallWithNonMockFunction (1 ms)
 [ RUN      ] MocksTest.MissingArguments

--- a/gjstest/internal/integration_tests/mocks.golden.xml
+++ b/gjstest/internal/integration_tests/mocks.golden.xml
@@ -109,8 +109,8 @@ Unsatisfied expectation at mocks_test.js:170:
 Expected 1 call; called 0 times.]]></failure>
  </testcase>
  <testcase name="MocksTest.ExpectCallWithNonMockFunction" time="0.01">
-  <failure><![CDATA[mocks_test.js:176
-TypeError: Supplied function is not a mock.]]></failure>
+  <failure><![CDATA[TypeError: Supplied function is not a mock.
+        at mocks_test.js:176]]></failure>
  </testcase>
  <testcase name="MocksTest.MissingArguments" time="0.01">
   <failure><![CDATA[mocks_test.js:190: Call matches no expectation.

--- a/gjstest/internal/integration_tests/registration.golden.txt
+++ b/gjstest/internal/integration_tests/registration.golden.txt
@@ -1,36 +1,36 @@
 [----------]
 [ RUN      ] HelperRegistrationTest.constructor
-registration_test.js:45
 Expected: true
 Actual:   false
+        at registration_test.js:45
 
 tearDown has been run.
 [  FAILED  ] HelperRegistrationTest.constructor (1 ms)
 [ RUN      ] HelperRegistrationTest.FooBar
-registration_test.js:40
 Expected: true
 Actual:   false
+        at registration_test.js:40
 
 tearDown has been run.
 [  FAILED  ] HelperRegistrationTest.FooBar (1 ms)
 [ RUN      ] HelperRegistrationTest.hasOwnProperty
-registration_test.js:50
 Expected: true
 Actual:   false
+        at registration_test.js:50
 
 tearDown has been run.
 [  FAILED  ] HelperRegistrationTest.hasOwnProperty (1 ms)
 [ RUN      ] HelperRegistrationTest.propertyIsEnumerable
-registration_test.js:56
 Expected: true
 Actual:   false
+        at registration_test.js:56
 
 tearDown has been run.
 [  FAILED  ] HelperRegistrationTest.propertyIsEnumerable (1 ms)
 [ RUN      ] HelperRegistrationTest.prototype
-registration_test.js:61
 Expected: true
 Actual:   false
+        at registration_test.js:61
 
 tearDown has been run.
 [  FAILED  ] HelperRegistrationTest.prototype (1 ms)

--- a/gjstest/internal/integration_tests/registration.golden.xml
+++ b/gjstest/internal/integration_tests/registration.golden.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="Google JS tests" failures="5" time="0.01">
  <testcase name="HelperRegistrationTest.constructor" time="0.01">
-  <failure><![CDATA[registration_test.js:45
-Expected: true
-Actual:   false]]></failure>
+  <failure><![CDATA[Expected: true
+Actual:   false
+        at registration_test.js:45]]></failure>
  </testcase>
  <testcase name="HelperRegistrationTest.FooBar" time="0.01">
-  <failure><![CDATA[registration_test.js:40
-Expected: true
-Actual:   false]]></failure>
+  <failure><![CDATA[Expected: true
+Actual:   false
+        at registration_test.js:40]]></failure>
  </testcase>
  <testcase name="HelperRegistrationTest.hasOwnProperty" time="0.01">
-  <failure><![CDATA[registration_test.js:50
-Expected: true
-Actual:   false]]></failure>
+  <failure><![CDATA[Expected: true
+Actual:   false
+        at registration_test.js:50]]></failure>
  </testcase>
  <testcase name="HelperRegistrationTest.propertyIsEnumerable" time="0.01">
-  <failure><![CDATA[registration_test.js:56
-Expected: true
-Actual:   false]]></failure>
+  <failure><![CDATA[Expected: true
+Actual:   false
+        at registration_test.js:56]]></failure>
  </testcase>
  <testcase name="HelperRegistrationTest.prototype" time="0.01">
-  <failure><![CDATA[registration_test.js:61
-Expected: true
-Actual:   false]]></failure>
+  <failure><![CDATA[Expected: true
+Actual:   false
+        at registration_test.js:61]]></failure>
  </testcase>
  <testcase name="BareRegistrationTest.FooBar" time="0.01"/>
 </testsuite>

--- a/gjstest/internal/js/test_environment.js
+++ b/gjstest/internal/js/test_environment.js
@@ -60,9 +60,11 @@ gjstest.internal.TestEnvironment =
   var me = this;
   this.reportFailure = function(message) {
     var userStack = me.userStack;
-    if (userStack.length != 0) {
-      var frame = userStack[0];
-      message = frame.fileName + ':' + frame.lineNumber + '\n' + message;
+    // Don't print out the last 2 frames, as they're always the same
+    // and internal to gjstest.
+    for (var i = 0; i < userStack.length - 2; i++) {
+      var frame = userStack[i];
+      message += '\n        at ' + frame.fileName + ':' + frame.lineNumber;
     }
 
     // Report the modified message.

--- a/gjstest/internal/js/test_environment_test.js
+++ b/gjstest/internal/js/test_environment_test.js
@@ -54,10 +54,16 @@ TestEnvironmentTest.prototype.ReportFailureWithoutUserStack = function() {
 };
 
 TestEnvironmentTest.prototype.ReportFailureWithUserStack = function() {
-  var frame = {fileName: 'taco.js', lineNumber: 17};
-  this.testEnv_.userStack.push(frame);
+  this.testEnv_.userStack.push({fileName: 'taco.js', lineNumber: 17});
+  this.testEnv_.userStack.push({fileName: 'taco.js', lineNumber: 27});
+  // Shouldn't print out the last 2 frames, as they're always the same
+  // and internal to gjstest.
+  this.testEnv_.userStack.push({fileName: 'register.js', lineNumber: 173});
+  this.testEnv_.userStack.push({fileName: 'run_test.js', lineNumber: 37});
 
-  expectCall(this.reportFailure_)('taco.js:17\nburrito');
+  expectCall(this.reportFailure_)('burrito\n' +
+      '        at taco.js:17\n' +
+      '        at taco.js:27');
   this.testEnv_.reportFailure('burrito');
 };
 


### PR DESCRIPTION
This is needed when the failed expectation is within a utility
method that is called multiple times during a test,
in order to determine which call resulted in a failure.