### PR TITLE
Fixed test breakage for v8 5.4.449

### DIFF
--- a/gjstest/internal/integration_tests/typed_arrays_test.js
+++ b/gjstest/internal/integration_tests/typed_arrays_test.js
@@ -399,12 +399,12 @@ TypedArraysTest.prototype.DataViewErrors = function() {
   // Construct with offset out of bounds.
   bytes = new Uint8Array(4);
   f = function() { new DataView(bytes.buffer, 4, 1); };
-  expectThat(f, throwsError(/INDEX_SIZE_ERR|RangeError.*Invalid data view/));
+  expectThat(f, throwsError(/INDEX_SIZE_ERR|RangeError.*Invalid (data view|DataView)/));
 
   // Construct with length too long.
   bytes = new Uint8Array(4);
   f = function() { new DataView(bytes.buffer, 2, 3); };
-  expectThat(f, throwsError(/INDEX_SIZE_ERR|RangeError.*Invalid data view/));
+  expectThat(f, throwsError(/INDEX_SIZE_ERR|RangeError.*Invalid (data view|DataView)/));
 
   // Read off end of view.
   bytes = new Uint8Array(100);


### PR DESCRIPTION
See src/messages.h:334 on following patch for corresponding v8 change.
https://github.com/v8/v8/commit/a3c13435aa822041b1fac25baf0e63c56185e4a1#diff-8fb2cf24b71a21c5b45a289bcb71ed2e