### PR TITLE
Modify createMockOfPrototype_ to be ES6 (and backwards) compatible.

### DIFF
--- a/gjstest/internal/js/mock_instance.js
+++ b/gjstest/internal/js/mock_instance.js
@@ -173,16 +173,16 @@ gjstest.internal.getAllPrototypeProperties_ = function(obj) {
   var props = {};
 
   while(obj) {
+    var nextObj = Object.getPrototypeOf(obj);
+    
     // We've reached the base Object - break.
-    if (obj.constructor.name == 'Object') {
-      break;
-    }
+    if (!nextObj) break;
 
     Object.getOwnPropertyNames(obj).forEach(function(p) {
       props[p] = true;
     });
 
-    obj = Object.getPrototypeOf(obj);
+    obj = nextObj;
   }
 
   return Object.getOwnPropertyNames(props);

--- a/gjstest/internal/js/mock_instance.js
+++ b/gjstest/internal/js/mock_instance.js
@@ -148,9 +148,26 @@ gjstest.internal.createMockOfPrototype_ =
   Tmp.prototype = prototype;
   var result = new Tmp;
 
+  // Object.getOwnPropertyNames does not include inherited methods. This method
+  // crawls up the inheritance chain and records all properties.
+  var inheritedPropertyNames = function(obj) {
+    var props = {};
+    while(obj) {
+      // We've reached the base Object - break.
+      if (obj.constructor.name == 'Object') {
+        break;
+      }
+      Object.getOwnPropertyNames(obj).forEach(function(p) {
+        props[p] = true;
+      });
+      obj = Object.getPrototypeOf(obj);
+    }
+    return Object.getOwnPropertyNames(props);
+  };
+
   // Mock each function in the prototype.
-  for (var name in result) {
-    if (typeof(result[name]) != 'function') continue;
+  for (const name of inheritedPropertyNames(Tmp.prototype)) {
+    if (name == 'constructor' || typeof(result[name]) != 'function') continue;
 
     result[name] = createMockFunction(baseName + '.' + name);
   }

--- a/gjstest/internal/js/mock_instance.js
+++ b/gjstest/internal/js/mock_instance.js
@@ -148,31 +148,44 @@ gjstest.internal.createMockOfPrototype_ =
   Tmp.prototype = prototype;
   var result = new Tmp;
 
-  // Object.getOwnPropertyNames does not include inherited methods. This method
-  // crawls up the inheritance chain and records all properties.
-  var inheritedPropertyNames = function(obj) {
-    var props = {};
-    while(obj) {
-      // We've reached the base Object - break.
-      if (obj.constructor.name == 'Object') {
-        break;
-      }
-      Object.getOwnPropertyNames(obj).forEach(function(p) {
-        props[p] = true;
-      });
-      obj = Object.getPrototypeOf(obj);
-    }
-    return Object.getOwnPropertyNames(props);
-  };
-
   // Mock each function in the prototype.
-  for (const name of inheritedPropertyNames(Tmp.prototype)) {
+  for (var name of gjstest.internal.getAllPrototypeProperties_(Tmp.prototype)) {
+    // Avoid mocking out the 'constructor' property.
     if (name == 'constructor' || typeof(result[name]) != 'function') continue;
 
     result[name] = createMockFunction(baseName + '.' + name);
   }
 
   return result;
+};
+
+/**
+ * Object.getOwnPropertyNames does not include inherited methods. This method
+ * crawls up the inheritance chain and records all properties.
+ *
+ * @param {?Object} obj
+ *
+ * @return {!Array<string>}
+ *
+ * @private
+ */
+gjstest.internal.getAllPrototypeProperties_ = function(obj) {
+  var props = {};
+
+  while(obj) {
+    // We've reached the base Object - break.
+    if (obj.constructor.name == 'Object') {
+      break;
+    }
+
+    Object.getOwnPropertyNames(obj).forEach(function(p) {
+      props[p] = true;
+    });
+
+    obj = Object.getPrototypeOf(obj);
+  }
+
+  return Object.getOwnPropertyNames(props);
 };
 
 /**

--- a/gjstest/internal/js/mock_instance_test.js
+++ b/gjstest/internal/js/mock_instance_test.js
@@ -74,6 +74,43 @@ MockInstanceTest.prototype.AddsMockMethods = function() {
   MyClass.prototype.taco = function() {};
   MyClass.prototype.burrito = function() {};
 
+  // Existence and enumerability assertions
+  expectTrue(MyClass.prototype.hasOwnProperty('taco'));
+  expectTrue(MyClass.prototype.hasOwnProperty('burrito'));
+  expectTrue(MyClass.prototype.propertyIsEnumerable('taco'));
+  expectTrue(MyClass.prototype.propertyIsEnumerable('burrito'));
+
+  // Mock functions
+  var mockFn_0 = function() {};
+  var mockFn_1 = function() {};
+
+  expectCall(this.createMockFunction_)('MyClass.taco')
+    .willOnce(returnWith(mockFn_0));
+
+  expectCall(this.createMockFunction_)('MyClass.burrito')
+    .willOnce(returnWith(mockFn_1));
+
+  // Properties
+  var result = this.createMockInstance_(MyClass);
+
+  expectEq(mockFn_0, result.taco);
+  expectEq(mockFn_1, result.burrito);
+};
+
+MockInstanceTest.prototype.AddsMockMethodsToAnonymousClass = function() {
+  // Class
+  function MyClass() {}
+  MyClass.prototype = {
+    taco: function() {},
+    burrito: function() {},
+  };
+
+  // Existence and enumerability assertions
+  expectTrue(MyClass.prototype.hasOwnProperty('taco'));
+  expectTrue(MyClass.prototype.hasOwnProperty('burrito'));
+  expectTrue(MyClass.prototype.propertyIsEnumerable('taco'));
+  expectTrue(MyClass.prototype.propertyIsEnumerable('burrito'));
+
   // Mock functions
   var mockFn_0 = function() {};
   var mockFn_1 = function() {};
@@ -98,6 +135,15 @@ MockInstanceTest.prototype.ES6AddsMockMethods = function() {
     taco() {}
     burrito() {}
   };
+
+  // Existence and enumerability assertions
+  expectTrue(MyClass.prototype.hasOwnProperty('taco'));
+  expectTrue(MyClass.prototype.hasOwnProperty('burrito'));
+
+  // ES6 prototype properties are not enumerable (will not be iterated over in
+  // a for-in loop)
+  expectFalse(MyClass.prototype.propertyIsEnumerable('taco'));
+  expectFalse(MyClass.prototype.propertyIsEnumerable('burrito'));
 
   // Mock functions
   var mockFn_0 = function() {};

--- a/gjstest/internal/js/mock_instance_test.js
+++ b/gjstest/internal/js/mock_instance_test.js
@@ -59,11 +59,45 @@ MockInstanceTest.prototype.CreatesInstanceOf = function() {
   expectTrue(result instanceof MyClass);
 };
 
+MockInstanceTest.prototype.ES6CreatesInstanceOf = function() {
+  const MyClass = class {
+    constructor() {}
+  };
+  var result = this.createMockInstance_(MyClass);
+
+  expectTrue(result instanceof MyClass);
+};
+
 MockInstanceTest.prototype.AddsMockMethods = function() {
   // Class
   function MyClass() {}
   MyClass.prototype.taco = function() {};
   MyClass.prototype.burrito = function() {};
+
+  // Mock functions
+  var mockFn_0 = function() {};
+  var mockFn_1 = function() {};
+
+  expectCall(this.createMockFunction_)('MyClass.taco')
+    .willOnce(returnWith(mockFn_0));
+
+  expectCall(this.createMockFunction_)('MyClass.burrito')
+    .willOnce(returnWith(mockFn_1));
+
+  // Properties
+  var result = this.createMockInstance_(MyClass);
+
+  expectEq(mockFn_0, result.taco);
+  expectEq(mockFn_1, result.burrito);
+};
+
+MockInstanceTest.prototype.ES6AddsMockMethods = function() {
+  // Class
+  const MyClass = class {
+    constructor() {}
+    taco() {}
+    burrito() {}
+  };
 
   // Mock functions
   var mockFn_0 = function() {};
@@ -92,9 +126,33 @@ MockInstanceTest.prototype.PreservesOtherPrototypeProperties = function() {
   expectEq(17, result.taco);
 };
 
+MockInstanceTest.prototype.ES6PreservesOtherPrototypeProperties = function() {
+  // Class
+  const MyClass = class {
+    constructor() {}
+  };
+  MyClass.prototype.taco = 17;
+
+  // Properties
+  var result = this.createMockInstance_(MyClass);
+  expectEq(17, result.taco);
+};
+
 MockInstanceTest.prototype.DoesNotCallConstructor = function() {
   var called = false;
   function MyClass() { called = true; }
+  this.createMockInstance_(MyClass);
+
+  expectFalse(called);
+};
+
+MockInstanceTest.prototype.ES6DoesNotCallConstructor = function() {
+  var called = false;
+  const MyClass = class {
+    constructor() {
+      called = true;
+    }
+  };
   this.createMockInstance_(MyClass);
 
   expectFalse(called);
@@ -115,6 +173,47 @@ MockInstanceTest.prototype.Inheritance = function() {
 
   ChildClass.prototype.enchilada = 19;
   ChildClass.prototype.queso = function() {};
+
+  // Mock functions
+  var mockFn_0 = function() {};
+  var mockFn_1 = function() {};
+
+  expectCall(this.createMockFunction_)('ChildClass.queso')
+    .willOnce(returnWith(mockFn_0));
+
+  expectCall(this.createMockFunction_)('ChildClass.burrito')
+    .willOnce(returnWith(mockFn_1));
+
+  // Properties
+  var result = this.createMockInstance_(ChildClass);
+
+  expectEq(mockFn_0, result.queso);
+  expectEq(mockFn_1, result.burrito);
+
+  expectEq(17, result.taco);
+  expectEq(19, result.enchilada);
+
+  // Types
+  expectTrue(result instanceof ParentClass);
+  expectTrue(result instanceof ChildClass);
+};
+
+MockInstanceTest.prototype.ES6Inheritance = function() {
+  // Parent class
+  const ParentClass = class {
+    constructor() {}
+    burrito() {}
+  };
+  ParentClass.prototype.taco = 17;
+
+  // Child class
+  const ChildClass = class extends ParentClass {
+    constructor() {
+      super();
+    }
+    queso() {}
+  };
+  ChildClass.prototype.enchilada = 19;
 
   // Mock functions
   var mockFn_0 = function() {};


### PR DESCRIPTION
The for-in loop in javascript iterates over all enumerable properties of an object (incl. inherited properties). Up until ES5, this included prototype properties of a class. However, in ES6 these prototype properties are no longer enumerable, and so createMockInstance as currently implemented will not mock out prototype methods in ES6. 

The backwards-compatible alternative for ES6 is to use Object.getOwnPropertyNames and crawl up the inheritance chain with Object.getPrototypeOf.