### PR TITLE
Fix type checking in matcher_types.js.

### DIFF
--- a/gjstest/public/matcher_types.js
+++ b/gjstest/public/matcher_types.js
@@ -70,13 +70,15 @@ gjstest.Matcher = function(description, negativeDescription, predicate) {
   if (description instanceof Function) {
     this.getDescription = description;
   } else {
-    this.getDescription = function() { return description; };
+    this.getDescription =
+        function() { return /** @type {string} */ (description); };
   }
 
   if (negativeDescription instanceof Function) {
     this.getNegativeDescription = negativeDescription;
   } else {
-    this.getNegativeDescription = function() { return negativeDescription; };
+    this.getNegativeDescription =
+        function() { return /** @type {string} */ (negativeDescription); };
   }
 };
 


### PR DESCRIPTION
Adds explicit casts to clarify two cases where the type checker isn't quite sophisticated enough to infer the correct types.

Background: Closure Compiler is trying to land a change to improve inference of qualified names.  An upshot of this is that it will soon understand that "this.getDescription" is supposed to be a `function(): string` (rather than just unknown as it does currently), which causes a type error when it tries to return a `string|function(): string` (note that the compiler does not currently propagate the flow-sensitive context that `description` is definitely a string from outside the closure to inside).