### PR TITLE
Adjust code to the API changes in V8 6.5.

### DIFF
--- a/gjstest/internal/cpp/run_tests.cc
+++ b/gjstest/internal/cpp/run_tests.cc
@@ -230,7 +230,7 @@ bool RunTests(
   for (uint32 i = 0; i < scripts.script_size(); ++i) {
     const NamedScript& script = scripts.script(i);
 
-    TryCatch try_catch;
+    TryCatch try_catch(isolate.get());
     const Local<Value> result =
         ExecuteJs(
             isolate.get(),

--- a/gjstest/internal/cpp/test_case.cc
+++ b/gjstest/internal/cpp/test_case.cc
@@ -115,13 +115,13 @@ void TestCase::Run() {
   // Create a test environment.
   Handle<Value> test_env_args[] = { log, report_failure, get_current_stack };
   const Local<Object> test_env =
-      test_env_constructor->NewInstance(
-          arraysize(test_env_args),
-          test_env_args);
-  CHECK(!test_env.IsEmpty());
+      test_env_constructor
+          ->NewInstance(isolate_->GetCurrentContext(), arraysize(test_env_args),
+                        test_env_args)
+          .ToLocalChecked();
 
   // Run the test.
-  TryCatch try_catch;
+  TryCatch try_catch(isolate_);
   Handle<Value> args[] = { test_function_, test_env };
   const Local<Value> result =
       run_test->Call(

--- a/gjstest/internal/cpp/v8_utils_test.cc
+++ b/gjstest/internal/cpp/v8_utils_test.cc
@@ -223,7 +223,7 @@ typedef V8UtilsTest DescribeErrorTest;
 TEST_F(DescribeErrorTest, NoError) {
   HandleScope handle_owner(isolate_.get());
 
-  TryCatch try_catch;
+  TryCatch try_catch(isolate_.get());
   EXPECT_EQ("", DescribeError(try_catch));
 }
 
@@ -232,7 +232,7 @@ TEST_F(DescribeErrorTest, NoMessage) {
 
   const std::string js = "throw new Error();";
 
-  TryCatch try_catch;
+  TryCatch try_catch(isolate_.get());
   ASSERT_TRUE(ExecuteJs(js, "taco.js").IsEmpty());
 
   EXPECT_EQ("taco.js:1: Error", DescribeError(try_catch));
@@ -243,7 +243,7 @@ TEST_F(DescribeErrorTest, WithMessage) {
 
   const std::string js = "throw new Error('foo');";
 
-  TryCatch try_catch;
+  TryCatch try_catch(isolate_.get());
   ASSERT_TRUE(ExecuteJs(js, "taco.js").IsEmpty());
 
   EXPECT_EQ("taco.js:1: Error: foo", DescribeError(try_catch));
@@ -295,7 +295,7 @@ static Handle<Value> AddToCounter(
     uint32* counter,
     const v8::FunctionCallbackInfo<Value>& cb_info) {
   CHECK_EQ(1, cb_info.Length());
-  *counter += cb_info[0]->ToUint32()->Value();
+  *counter += cb_info[0]->Uint32Value(isolate->GetCurrentContext()).ToChecked();
   return v8::Undefined(isolate);
 }
 


### PR DESCRIPTION
V8 6.5 removed deprecated functions (see https://bit.ly/v8-api-changes).

Changes that apply to gjstest:
- TryCatch constructor requires an isolate.
- Function::NewInstance returns MaybeLocal<>.
- ScriptCompiler::CompileUnbound is renamed to CompileUnboundScript
  and returns a MaybeLocal<>.
- Value::ToUint32 requires a context and returns a Maybe<>.