### PR TITLE
Keep `error.stack` a string, for compatibility with other tools.

### DIFF
--- a/gjstest/internal/js/error_utils.js
+++ b/gjstest/internal/js/error_utils.js
@@ -28,7 +28,9 @@ gjstest.internal.installPrepareStackTrace = function() {
       function(error, structuredStack) {
         // Save the structured stack.
         error.structuredStack = structuredStack;
-        // Prepare the usual v8 formatted stack trace, for compatibility.
+
+        // Prepare the usual v8 formatted stack trace, for compatibility with
+        // tools that parse stack traces (like jasmine).
         return error.name + ': ' + error.message +
             structuredStack.map(function(callSite) {
               return '\n   at ' + callSite.toString();

--- a/gjstest/internal/js/error_utils.js
+++ b/gjstest/internal/js/error_utils.js
@@ -26,7 +26,13 @@
 gjstest.internal.installPrepareStackTrace = function() {
   Error.prepareStackTrace =
       function(error, structuredStack) {
-        return structuredStack;
+        // Save the structured stack.
+        error.structuredStack = structuredStack;
+        // Prepare the usual v8 formatted stack trace, for compatibility.
+        return error.name + ': ' + error.message +
+            structuredStack.map(function(callSite) {
+              return '\n   at ' + callSite.toString();
+            }).join();
       };
 };
 
@@ -41,8 +47,8 @@ gjstest.internal.installPrepareStackTrace = function() {
  * @suppress {missingProperties}
  */
 gjstest.internal.getErrorStack = function(error) {
-  // Grab the structured stack.
-  var structuredStack = error.stack;
+  // Invoke prepareStackTrace to capture the structured stack.
+  var structuredStack = error.stack && error.structuredStack;
 
   // Some errors don't return a stack. (This was true of stack overflows in
   // earlier versions of v8, for example.) Some browsers always supply the stack

--- a/gjstest/internal/js/error_utils_test.js
+++ b/gjstest/internal/js/error_utils_test.js
@@ -18,7 +18,8 @@ registerTestSuite(ErrorUtilsTest);
 
 ErrorUtilsTest.prototype.FallsBackOnEvalOrigin = function() {
   var errorStack = gjstest.internal.getErrorStack(/** @type {!Error} */ ({
-    stack: [
+    stack: 'formatted stack',
+    structuredStack: [
       new FakeCallSite('', 'evalfoobar.js', 11),
       new FakeCallSite('foobar.js', 'evalfoobar.js', 11),
       new FakeCallSite('foobar.js', '', 11)

--- a/gjstest/internal/js/targets.mk
+++ b/gjstest/internal/js/targets.mk
@@ -97,6 +97,7 @@ $(eval $(call compiled_js_library, \
 ######################################################
 
 $(eval $(call js_test,gjstest/internal/js/call_expectation))
+$(eval $(call js_test,gjstest/internal/js/error_utils))
 $(eval $(call js_test,gjstest/internal/js/expect_that))
 $(eval $(call js_test,gjstest/internal/js/mock_function))
 $(eval $(call js_test,gjstest/internal/js/mock_instance))


### PR DESCRIPTION
Capture the stack frames in `error.structuredStack`, instead of overwriting `error.stack`.

When running in a browser, this makes gjstest play nicely with other tools.