### PR TITLE
Adapt usage of v8 API to v7.0 release.

### DIFF
--- a/gjstest/internal/cpp/test_case.cc
+++ b/gjstest/internal/cpp/test_case.cc
@@ -33,7 +33,9 @@ namespace gjstest {
 
 // Get a reference to the function of the supplied name.
 Local<Function> TestCase::GetFunctionNamed(const string& name) const {
-  const Local<Value> result = ExecuteJs(isolate_, name, "");
+  const Local<Value> result =
+      ExecuteJs(isolate_, isolate_->GetCurrentContext(), name, "")
+          .ToLocalChecked();
   CHECK(result->IsFunction()) << "Error getting reference to " << name;
   return Local<Function>::Cast(result);
 }
@@ -42,7 +44,7 @@ Local<Function> TestCase::GetFunctionNamed(const string& name) const {
 v8::Handle<v8::Value> TestCase::LogString(
     const v8::FunctionCallbackInfo<v8::Value>& cb_info) {
   CHECK_EQ(1, cb_info.Length());
-  const string message = ConvertToString(cb_info[0]);
+  const string message = ConvertToString(isolate_, cb_info[0]);
   StringAppendF(&this->output, "%s\n", message.c_str());
 
   return v8::Undefined(isolate_);
@@ -53,7 +55,7 @@ v8::Handle<v8::Value> TestCase::LogString(
 v8::Handle<v8::Value> TestCase::RecordFailure(
     const v8::FunctionCallbackInfo<v8::Value>& cb_info) {
   CHECK_EQ(1, cb_info.Length());
-  const string message = ConvertToString(cb_info[0]);
+  const string message = ConvertToString(isolate_, cb_info[0]);
 
   this->succeeded = false;
   StringAppendF(&this->output, "%s\n\n", message.c_str());
@@ -133,7 +135,7 @@ void TestCase::Run() {
   if (result.IsEmpty()) {
     succeeded = false;
 
-    const string description = DescribeError(try_catch);
+    const string description = DescribeError(isolate_, try_catch);
     StringAppendF(&output, "%s\n", description.c_str());
     StringAppendF(&failure_output, "%s\n", description.c_str());
   }

--- a/gjstest/internal/cpp/v8_utils.h
+++ b/gjstest/internal/cpp/v8_utils.h
@@ -36,7 +36,8 @@ typedef std::shared_ptr<v8::Isolate> IsolateHandle;
 IsolateHandle CreateIsolate();
 
 // Convert the supplied value to a UTF-8 string.
-std::string ConvertToString(const v8::Handle<v8::Value>& value);
+std::string ConvertToString(v8::Isolate* isolate,
+                            const v8::Handle<v8::Value>& value);
 
 // Convert the supplied value, which must be an array, into a vector of strings.
 void ConvertToStringVector(
@@ -51,14 +52,14 @@ void ConvertToStringVector(
 //
 // If filename is non-empty, it will be given to v8 to improve stack traces for
 // errors.
-v8::Local<v8::Value> ExecuteJs(
-    v8::Isolate* isolate,
-    const std::string& js,
-    const std::string& filename);
+v8::MaybeLocal<v8::Value> ExecuteJs(v8::Isolate* isolate,
+                                    v8::Local<v8::Context> context,
+                                    const std::string& js,
+                                    const std::string& filename);
 
 // Return a human-readable string describing the error caught by the supplied
 // try-catch block.
-std::string DescribeError(const v8::TryCatch& try_catch);
+std::string DescribeError(v8::Isolate*, const v8::TryCatch& try_catch);
 
 // C++ functions exported by v8 must accept a FunctionCallbackInfo<Value> object
 // and return a handle to a Value.

--- a/gjstest/internal/integration_tests/syntax_error.golden.txt
+++ b/gjstest/internal/integration_tests/syntax_error.golden.txt
@@ -1,1 +1,1 @@
-syntax_error.js:21: SyntaxError: Unexpected end of input
+syntax_error.js:22: SyntaxError: Unexpected end of input


### PR DESCRIPTION
Here is a change to make gjstest compile against v8 7.0. Changes mostly are about using MaybeLocal and passing isolate and context into functions where now needed.

I had to tweak the Makefile on my local machine to also link against pthread and disable deprecation warnings but I was not sure whether that is a local issue.

```
CXXFLAGS += -Wno-deprecated-declarations
CXXFLAGS += -lpthread
```